### PR TITLE
reduce amount of years loaded on-start

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@ const parquetUrls = urlParams.getAll('parquet').map(fixUrl);
  * St. Olaf course data: patch data urls
  */
  const getCourseDataUrls = () => {
-    const startYear = 1994
     const currentYear = new Date().getFullYear()
+    const startYear = currentYear - 4
 
     const termsUrl = 'https://stolaf.dev/course-data/terms'
 


### PR DESCRIPTION
Instead of presenting 1994-present, let’s optimize for current year - 4 years. This cuts down on the initial loading time to fetch and parse all the datasets.