### PR TITLE
wrap csv data fetch/parse with try/except

### DIFF
--- a/webworker.js
+++ b/webworker.js
@@ -123,17 +123,20 @@ async function startDatasette(settings) {
                 table_names.add(bit)
 
                 if source_type == "csv":
-                    tracker = TypeTracker()
-                    response = await pyfetch(url)
-                    with open("csv.csv", "wb") as fp:
-                        fp.write(await response.bytes())
-                    db[bit].insert_all(
-                        tracker.wrap(rows_from_file(open("csv.csv", "rb"), Format.CSV)[0]),
-                        alter=True
-                    )
-                    db[bit].transform(
-                        types=tracker.types
-                    )
+                  try:
+                      tracker = TypeTracker()
+                      response = await pyfetch(url)
+                      with open("csv.csv", "wb") as fp:
+                          fp.write(await response.bytes())
+                      db[bit].insert_all(
+                          tracker.wrap(rows_from_file(open("csv.csv", "rb"), Format.CSV)[0]),
+                          alter=True
+                      )
+                      db[bit].transform(
+                          types=tracker.types
+                      )
+                  except Exception as error:
+                      print(f"Failed to fetch or process CSV from {url}: {error}")
                 elif source_type == "json":
                     pk = None
                     response = await pyfetch(url)


### PR DESCRIPTION
Fixes an issue where a requested term's csv data doesn't exist and exits the app from loading altogether. 

```
Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 573, in eval_code_async
    await CodeRunner(
  File "/lib/python311.zip/_pyodide/_base.py", line 395, in run_async
    await coroutine
  File "<exec>", line 74, in <module>
  File "/lib/python3.11/site-packages/sqlite_utils/db.py", line 2963, in insert_all
    chunk = list(chunk)
            ^^^^^^^^^^^
  File "/lib/python3.11/site-packages/sqlite_utils/db.py", line 3492, in fix_square_braces
    for record in records:
  File "/lib/python3.11/site-packages/sqlite_utils/utils.py", line 349, in wrap
    for row in iterator:
  File "/lib/python3.11/site-packages/sqlite_utils/utils.py", line 214, in _extra_key_strategy
    raise RowError(
sqlite_utils.utils.RowError: Row {'<!DOCTYPE html>': '        font-family: "Helvetica Neue"'} contained these extra values: [' Helvetica', ' Arial', ' sans-serif;']
```