### PR TITLE
smaller recent-only catalog sqlite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Browse the St. Olaf course catalog with [Datasette](https://datasette.io/), running
 entirely in the browser via [datasette-lite](https://github.com/simonw/datasette-lite).
 
-By default the page loads `https://stolaf.dev/course-data/catalog.db`, which holds
+By default the page loads `https://stolaf.dev/course-data/catalog-recent.db`, which holds
 sections, instructors, general education requirements and meeting times as related
 tables. All of the datasette-lite query parameters still work, so `?url=`, `?csv=`,
 `?json=`, `?parquet=`, `?sql=` and `?memory=1` load other data instead of the catalog.

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ const parquetUrls = urlParams.getAll('parquet').map(fixUrl);
  * so Datasette can link between them. Loading it directly also avoids
  * rebuilding those tables from per-term CSVs on every page load.
  */
-const catalogUrl = 'https://stolaf.dev/course-data/catalog.db';
+const catalogUrl = 'https://stolaf.dev/course-data/catalog-recent.db';
 
 const sqliteUrlParams = urlParams.getAll('url').map(fixUrl);
 let sqliteUrls = sqliteUrlParams;

--- a/tests/test_datasette_lite.py
+++ b/tests/test_datasette_lite.py
@@ -55,13 +55,13 @@ def test_initial_load(dslite: Page):
 
 
 def test_default_loads_course_catalog(dslite: Page):
-    assert [el.inner_text() for el in dslite.query_selector_all("h2")] == ["catalog"]
+    assert [el.inner_text() for el in dslite.query_selector_all("h2")] == ["catalog-recent"]
 
 
 def test_catalog_has_expected_tables(dslite: Page):
     h2 = dslite.query_selector("h2")
     h2.query_selector("a").click()
-    expect(dslite).to_have_title("catalog")
+    expect(dslite).to_have_title("catalog-recent")
     table_names = {
         el.inner_text() for el in dslite.query_selector_all("div.db-table h3 a")
     }
@@ -69,7 +69,7 @@ def test_catalog_has_expected_tables(dslite: Page):
 
 
 def test_can_query_section_table(static_server, browser: Browser):
-    page = load_page(browser, "#/catalog?sql=select+count(*)+from+section")
+    page = load_page(browser, "#/catalog-recent?sql=select+count(*)+from+section")
     table = page.query_selector("table.rows-and-columns")
     count = int(table.query_selector("tbody td").inner_text())
     assert count > 0


### PR DESCRIPTION
Load `catalog-recent.db` (last 5 years) instead of `catalog.db` (all history).

- Depends upon https://github.com/StoDevX/course-data-tools/pull/27

## Why

The full catalog is 38MB plain / 11.5MB gzipped — mostly historical data most users don't need. The recent-only version covers the same rolling five-year window the old CSV approach did, at 4MB plain / 1.4MB gzipped. That's a ~8x reduction in download size.

## Changes

- `index.html` — `catalogUrl` points to `catalog-recent.db`
- `README.md` — updated URL in the description
- `tests/test_datasette_lite.py` — database name expectations changed to `catalog-recent`
